### PR TITLE
Extended logging of the error for the config loader

### DIFF
--- a/packages/cypress-cloud/lib/config.ts
+++ b/packages/cypress-cloud/lib/config.ts
@@ -48,6 +48,7 @@ export function getCurrentsConfig(): CurrentsConfig {
     return _config;
   } catch (e) {
     warn("failed to load currents config file: %s", configFilePath);
+    debug("failure details: %s", e);
     _config = defaultConfig;
     return _config;
   }


### PR DESCRIPTION
In some cases, it could be helpful to see the original error to understand why the config was not loaded.