### PR TITLE
Update README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -36,7 +36,7 @@ module.exports = {
   projectId: "Ij0RfK",
   recordKey: "xxx",
   // Sorry Cypress users - set the director service URL
-  cloudServiceUrl: "http://cy.currents.dev",
+  cloudServiceUrl: "https://cy.currents.dev",
 };
 ```
 


### PR DESCRIPTION
The changed example configuration block mentions http but the example below mentions https.

Using http resulted in the following error (remote IP hidden): 
```
Connecting to cloud orchestration service...
 WARNING  Network request failed: 'connect ECONNREFUSED XX.XX.XX.XX:80'. Next attempt is in 15s (1/3).
```