### PR TITLE
fix: validate params and show verbose errors

### DIFF
--- a/examples/webapp/README.md
+++ b/examples/webapp/README.md
@@ -1,12 +1,27 @@
 # Example Usage of cypress-cloud
 
-## CLI Usage
+To run the example, make sure that you have an account at https://app.currents.dev or Sorry Cypress instance. You can start a basic local instance of sorry-cypress:
 
-To run the example, make sure that you have an account at https://app.currents.dev (or Sorry Cypress instance).
+```sh
+docker run -p 1234:1234 --platform linux/amd64 agoldis/sorry-cypress-director
+```
 
-### Configuration
+## Configuration
 
 Update `currents.config.js` with the `projectId`, `recordKey` obtained from a cloud orchestration service. Sorry Cypress users - use the director service URL as `cloudServiceUrl`.
+
+```js
+// currents.config.js
+module.exports = {
+  projectId: "yyy", // the projectId, can be any values for sorry-cypress users
+  recordKey: "xxx", // the record key, can be any value for sorry-cypress users
+  cloudServiceUrl: "http://localhost:1234", // Sorry Cypress users - set the director service URL, Currents customer - remove this option
+};
+```
+
+## CLI Usage
+
+Use the following commands to run cypress tests
 
 ### E2E tests
 

--- a/examples/webapp/currents.config.js
+++ b/examples/webapp/currents.config.js
@@ -3,10 +3,10 @@ module.exports = {
     batchSize: 3, // how many specs to send in one batch
   },
   component: {
-    batchSize: 3, // how many specs to send in one batch
+    batchSize: 5, // how many specs to send in one batch
   },
   projectId: !!(process.env.GITHUB_ACTION || process.env.CIRCLE_BRANCH)
     ? "Ij0RfK"
     : "l4zuz8",
-  // recordKey: process.env.CURRENTS_RECORD_KEY,
+  // cloudServiceUrl: "http://localhost:1234",
 };

--- a/examples/webapp/scripts/currents-script.ts
+++ b/examples/webapp/scripts/currents-script.ts
@@ -7,6 +7,7 @@ import { run } from "cypress-cloud";
 
   const summarizedResults = await run({
     ciBuildId: `run-api-smoke-${new Date().toISOString()}`,
+    spec: ["cypress/e2e_smoke/*.spec.js"],
     projectId,
     key,
   });

--- a/examples/webapp/scripts/currents-script.ts
+++ b/examples/webapp/scripts/currents-script.ts
@@ -9,8 +9,6 @@ import { run } from "cypress-cloud";
     ciBuildId: `run-api-smoke-${new Date().toISOString()}`,
     projectId,
     key,
-    testingType: "e2e",
-    record: true,
   });
 
   assert(summarizedResults?.passes === 1);

--- a/examples/webapp/scripts/currents-script.ts
+++ b/examples/webapp/scripts/currents-script.ts
@@ -6,14 +6,11 @@ import { run } from "cypress-cloud";
   const key = process.env.CURRENTS_RECORD_KEY || "";
 
   const summarizedResults = await run({
+    ciBuildId: `run-api-smoke-${new Date().toISOString()}`,
     projectId,
     key,
-    spec: ["cypress/e2e_smoke/*.spec.js"],
     testingType: "e2e",
     record: true,
-    ciBuildId: `run-api-smoke-${new Date().toISOString()}`,
-    tag: ["run-api-smoke"],
-    batchSize: 1,
   });
 
   assert(summarizedResults?.passes === 1);

--- a/packages/cypress-cloud/index.ts
+++ b/packages/cypress-cloud/index.ts
@@ -16,9 +16,9 @@ import { bold, divider, info, spacer, title } from "./lib/log";
 import { getPlatformInfo } from "./lib/platform";
 import { runTillDone } from "./lib/runner";
 import { summaryTable } from "./lib/table";
+import { validateRequiredParams } from "./lib/validateParams";
 
 const debug = Debug("currents:index");
-
 /**
  * Run the Cypress tests and return the results.
  *
@@ -36,10 +36,11 @@ export async function run(params: CurrentsRunParameters) {
     ciBuildId,
     tag,
     testingType,
-    batchSize,
+    batchSize = 1,
   } = params;
 
   debug("run api params %o", params);
+  validateRequiredParams(params);
 
   // get the actual config parsed by Cypress
   const config = await getConfig(params);

--- a/packages/cypress-cloud/index.ts
+++ b/packages/cypress-cloud/index.ts
@@ -35,7 +35,7 @@ export async function run(params: CurrentsRunParameters) {
     parallel,
     ciBuildId,
     tag,
-    testingType,
+    testingType = "e2e",
     batchSize = 1,
   } = params;
 
@@ -68,6 +68,7 @@ export async function run(params: CurrentsRunParameters) {
     }; Batch Size: ${batchSize}`
   );
   info("Connecting to cloud orchestration service...");
+
   const run = await createRun({
     ci,
     specs: specs.map((spec) => spec.relative),

--- a/packages/cypress-cloud/index.ts
+++ b/packages/cypress-cloud/index.ts
@@ -19,10 +19,11 @@ import { summaryTable } from "./lib/table";
 import { validateRequiredParams } from "./lib/validateParams";
 
 const debug = Debug("currents:index");
+
 /**
  * Run the Cypress tests and return the results.
  *
- * @augments RunOptions
+ * @augments CurrentsRunParameters
  * @returns {TestsResult | undefined} The test results, or undefined if no tests were run.
  */
 export async function run(params: CurrentsRunParameters) {

--- a/packages/cypress-cloud/lib/api/types/run.ts
+++ b/packages/cypress-cloud/lib/api/types/run.ts
@@ -20,7 +20,7 @@ export type CreateRunPayload = {
   tags?: string[];
   testingType: "e2e" | "component";
   timeout?: number;
-  batchSize: number;
+  batchSize?: number;
 };
 
 export type CloudWarning = {

--- a/packages/cypress-cloud/lib/ciProvider.ts
+++ b/packages/cypress-cloud/lib/ciProvider.ts
@@ -662,7 +662,9 @@ function checkForCiBuildFromCi(ciProvider: string | null) {
   if (ciProvider && detectableCiBuildIdProviders().includes(ciProvider))
     return true;
 
-  throw new Error("We could not determine a unique CI build ID");
+  throw new Error(
+    "We could not determine CI build ID from the environment. Please provide a unique build ID using the --ci-build-id flag or 'ciBuildId' parameter for 'run' method."
+  );
 }
 
 export function list() {

--- a/packages/cypress-cloud/lib/log.ts
+++ b/packages/cypress-cloud/lib/log.ts
@@ -17,7 +17,7 @@ export const success = (...args: unknown[]) =>
   log(chalk.green(util.format(...args)));
 
 export const error = (...args: unknown[]) =>
-  log(withError(util.format(...args)));
+  log(withError(util.format(...args)) + "\n");
 
 type Color = "red" | "green" | "yellow" | "blue" | "magenta" | "cyan" | "white";
 export const title = (color: Color, ...args: unknown[]) =>

--- a/packages/cypress-cloud/lib/validateParams.ts
+++ b/packages/cypress-cloud/lib/validateParams.ts
@@ -5,8 +5,6 @@ export function validateRequiredParams(params: CurrentsRunParameters) {
   const requiredParameters: Array<keyof CurrentsRunParameters> = [
     "key",
     "projectId",
-    "ciBuildId",
-    "testingType",
   ];
   requiredParameters.forEach((key) => {
     if (typeof params[key] === "undefined") {

--- a/packages/cypress-cloud/lib/validateParams.ts
+++ b/packages/cypress-cloud/lib/validateParams.ts
@@ -1,0 +1,21 @@
+import { CurrentsRunParameters } from "../types";
+import { error } from "./log";
+
+export function validateRequiredParams(params: CurrentsRunParameters) {
+  const requiredParameters: Array<keyof CurrentsRunParameters> = [
+    "key",
+    "projectId",
+    "ciBuildId",
+    "testingType",
+  ];
+  requiredParameters.forEach((key) => {
+    if (typeof params[key] === "undefined") {
+      error(
+        'Missing required parameter "%s". Please provide at least the following parameters: %s',
+        key,
+        requiredParameters.join(", ")
+      );
+      throw new Error("Missing required parameter");
+    }
+  });
+}

--- a/packages/cypress-cloud/types.ts
+++ b/packages/cypress-cloud/types.ts
@@ -141,6 +141,6 @@ export type CurrentsRunParameters = StrippedCypressModuleAPIOptions & {
   projectId: string;
 
   /** The batch size defines how many spec files will be served in one orchestration "batch". If not specified, will use the projectId from currents.config.js, the default value is 3 */
-  batchSize: number;
+  batchSize?: number;
 };
 export type ArrayItemType<T> = T extends (infer U)[] ? U : T;

--- a/packages/cypress-cloud/types.ts
+++ b/packages/cypress-cloud/types.ts
@@ -122,24 +122,26 @@ export type StrippedCypressModuleAPIOptions = Omit<
   | "ciBuildId"
 >;
 
-// The parameters Currents accepts via its run API.
-// Explicitly add cloud-related parameters to avoid confusion with CypressModuleAPIRunOptions
 export type CurrentsRunParameters = StrippedCypressModuleAPIOptions & {
-  parallel?: boolean;
+  /** The CI build ID to use for the run */
   ciBuildId?: string;
-  group?: string;
-  testingType?: TestingType;
+  /** The batch size defines how many spec files will be served in one orchestration "batch". If not specified, will use the projectId from currents.config.js, the default value is 1 (i.e. no batching) */
+  batchSize?: number;
+  /** The environment variables to use for the run */
   env?: Record<string, unknown>;
-  spec?: string[];
-  tag?: string[];
-
+  /** The group id to use for the run */
+  group?: string;
   /**  The record key to use */
   key: string;
-
-  /** The project ID to use. If not specified, will use the projectId from currents.config.js or process.env.CURRENTS_PROJECT_ID */
+  /** Whether to run the spec files in parallel */
+  parallel?: boolean;
+  /** The project ID to use. */
   projectId: string;
-
-  /** The batch size defines how many spec files will be served in one orchestration "batch". If not specified, will use the projectId from currents.config.js, the default value is 3 */
-  batchSize?: number;
+  /** The array of spec patterns for the execution */
+  spec?: string[];
+  /** The array of tags for the execution */
+  tag?: string[];
+  /** "e2e" or "component", the default value is "e2e" */
+  testingType?: TestingType;
 };
 export type ArrayItemType<T> = T extends (infer U)[] ? U : T;

--- a/packages/cypress-cloud/types.ts
+++ b/packages/cypress-cloud/types.ts
@@ -128,8 +128,7 @@ export type CurrentsRunParameters = StrippedCypressModuleAPIOptions & {
   parallel?: boolean;
   ciBuildId?: string;
   group?: string;
-  testingType: TestingType;
-  record: boolean;
+  testingType?: TestingType;
   env?: Record<string, unknown>;
   spec?: string[];
   tag?: string[];


### PR DESCRIPTION
Not providing the required parameters causes errors on the backend.
Also, some parameters that are not required are marked as mandatory in TS. 

This PR:
- adds validation for required params
- marks non-requires params as optional
- set defaults for some params