### PR TITLE
Implement --auto-cancel-after-failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2852,6 +2852,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/bluebird": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==",
+      "dev": true
+    },
     "node_modules/@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -3839,8 +3845,7 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "license": "MIT"
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/boxen": {
       "version": "7.0.1",
@@ -14568,13 +14573,14 @@
       }
     },
     "packages/cypress-cloud": {
-      "version": "1.5.6",
+      "version": "1.5.7-beta.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@cypress/commit-info": "^2.2.0",
         "async-wait-until": "^2.0.12",
         "axios": "^1.2.0",
         "axios-retry": "^3.4.0",
+        "bluebird": "^3.7.2",
         "chalk": "^4.1.2",
         "commander": "^10.0.0",
         "common-path-prefix": "^3.0.0",
@@ -14598,6 +14604,7 @@
         "@release-it/conventional-changelog": "^5.1.1",
         "@swc/core": "^1.3.23",
         "@swc/jest": "^0.2.24",
+        "@types/bluebird": "^3.5.38",
         "@types/debug": "^4.1.7",
         "@types/getos": "^3.0.1",
         "@types/is-ci": "^3.0.0",
@@ -16422,6 +16429,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bluebird": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
+      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==",
+      "dev": true
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -18067,6 +18080,7 @@
         "@release-it/conventional-changelog": "^5.1.1",
         "@swc/core": "^1.3.23",
         "@swc/jest": "^0.2.24",
+        "@types/bluebird": "*",
         "@types/debug": "^4.1.7",
         "@types/getos": "^3.0.1",
         "@types/is-ci": "^3.0.0",
@@ -18075,6 +18089,7 @@
         "async-wait-until": "^2.0.12",
         "axios": "^1.2.0",
         "axios-retry": "^3.4.0",
+        "bluebird": "^3.7.2",
         "chalk": "^4.1.2",
         "commander": "^10.0.0",
         "common-path-prefix": "^3.0.0",

--- a/packages/cypress-cloud/bin/lib/program.ts
+++ b/packages/cypress-cloud/bin/lib/program.ts
@@ -86,6 +86,12 @@ export const createProgram = (command: Command = new Command()) =>
       "-t, --tag <tag>",
       "comma-separated tag(s) for recorded runs in Currents",
       parseCommaSeparatedList
+    )
+    .addOption(
+      new Option(
+        "--auto-cancel-after-failures <number | false>",
+        "Automatically abort the run after the specified number of failed tests. Overrides the default project settings. If set, must be a positive integer or 'false' to disable (Currents-only)"
+      ).argParser(parseAutoCancelFailures)
     );
 
 export const program = createProgram();
@@ -95,4 +101,20 @@ function parseCommaSeparatedList(value: string, previous: string[] = []) {
     return previous.concat(value.split(",").map((t) => t.trim()));
   }
   return previous;
+}
+
+function parseAutoCancelFailures(value: string): number | false {
+  if (value === "false") {
+    return false;
+  }
+
+  const parsedValue = parseInt(value, 10);
+
+  if (isNaN(parsedValue) || parsedValue < 1) {
+    throw new Error(
+      "Invalid argument provided. Must be a positive integer or 'false'."
+    );
+  }
+
+  return parsedValue;
 }

--- a/packages/cypress-cloud/lib/api/types/instance.ts
+++ b/packages/cypress-cloud/lib/api/types/instance.ts
@@ -123,4 +123,7 @@ export type UpdateInstanceResultsMergedPayload = {
 export interface UpdateInstanceResultsResponse {
   videoUploadUrl?: string | null;
   screenshotUploadUrls: ScreenshotUploadInstruction[];
+  cloud?: {
+    shouldCancel: false | string;
+  };
 }

--- a/packages/cypress-cloud/lib/api/types/run.ts
+++ b/packages/cypress-cloud/lib/api/types/run.ts
@@ -1,5 +1,5 @@
 import { CiParams, CiProvider } from "cypress-cloud/lib/ciProvider";
-import { Platform } from "cypress-cloud/types";
+import { Platform, ValidatedCurrentsParameters } from "cypress-cloud/types";
 
 export type CreateRunPayload = {
   ci: {
@@ -21,6 +21,7 @@ export type CreateRunPayload = {
   testingType: "e2e" | "component";
   timeout?: number;
   batchSize?: number;
+  autoCancelAfterFailures: ValidatedCurrentsParameters["autoCancelAfterFailures"];
 };
 
 export type CloudWarning = {

--- a/packages/cypress-cloud/lib/config/config.ts
+++ b/packages/cypress-cloud/lib/config/config.ts
@@ -27,10 +27,6 @@ export function getCurrentsConfig(): CurrentsConfig {
   if (_config) {
     return _config;
   }
-
-  const configFilePath = getConfigFilePath();
-  debug("loading currents config file from '%s'", configFilePath);
-
   const defaultConfig: CurrentsConfig = {
     e2e: {
       batchSize: 3,
@@ -41,8 +37,12 @@ export function getCurrentsConfig(): CurrentsConfig {
     cloudServiceUrl: "https://cy.currents.dev",
   };
 
+  const configFilePath = getConfigFilePath();
   try {
-    const fsConfig = require(configFilePath);
+    const resovledPath = path.resolve(configFilePath);
+    debug("loading currents config file from '%s'", resovledPath);
+
+    const fsConfig = require(resovledPath);
     _config = {
       ...defaultConfig,
       ...fsConfig,
@@ -95,5 +95,5 @@ export async function getMergedConfig(params: ValidatedCurrentsParameters) {
 }
 
 function getConfigFilePath(explicitLocation = null) {
-  return path.resolve(explicitLocation ?? process.cwd(), "currents.config.js");
+  return explicitLocation ?? process.cwd(), "currents.config.js";
 }

--- a/packages/cypress-cloud/lib/lang.ts
+++ b/packages/cypress-cloud/lib/lang.ts
@@ -1,3 +1,10 @@
+import bluebird from "bluebird";
+
+bluebird.Promise.config({
+  cancellation: true,
+});
+export const BPromise = bluebird.Promise;
+
 export const safe =
   <T extends any[], R extends any>(
     fn: (...args: T) => Promise<R>,

--- a/packages/cypress-cloud/lib/pubsub.ts
+++ b/packages/cypress-cloud/lib/pubsub.ts
@@ -1,0 +1,5 @@
+import EventEmitter from "events";
+export enum Event {
+  RUN_CANCELLED = "runCancelled",
+}
+export const pubsub = new EventEmitter();

--- a/packages/cypress-cloud/lib/results/uploadResults.ts
+++ b/packages/cypress-cloud/lib/results/uploadResults.ts
@@ -10,6 +10,7 @@ import { uploadArtifacts, uploadStdoutSafe } from "../artifacts";
 import { getInitialOutput } from "../capture";
 import { isCurrents } from "../env";
 import { warn } from "../log";
+import { setCancellationReason } from "../state";
 import { getInstanceResultPayload, getInstanceTestsPayload } from "./results";
 const debug = Debug("currents:results");
 
@@ -52,12 +53,16 @@ export async function processCypressResults(
   const instanceResults = getInstanceResultPayload(run);
   const instanceTests = getInstanceTestsPayload(run, results.config);
 
-  const { videoUploadUrl, screenshotUploadUrls } = await reportResults(
+  const { videoUploadUrl, screenshotUploadUrls, cloud } = await reportResults(
     instanceId,
     instanceTests,
     instanceResults
   );
 
+  if (cloud?.shouldCancel) {
+    debug("instance %s should cancel", instanceId);
+    setCancellationReason(cloud.shouldCancel);
+  }
   debug("instance %s artifact upload instructions %o", instanceId, {
     videoUploadUrl,
     screenshotUploadUrls,

--- a/packages/cypress-cloud/lib/state.ts
+++ b/packages/cypress-cloud/lib/state.ts
@@ -1,0 +1,18 @@
+import { Event, pubsub } from "./pubsub";
+
+interface ExecutionState {
+  cancellationReason: string | null;
+}
+const state: ExecutionState = {
+  cancellationReason: null,
+};
+
+export const setCancellationReason = (reason: string) => {
+  if (state.cancellationReason) {
+    return;
+  }
+  state.cancellationReason = reason;
+  pubsub.emit(Event.RUN_CANCELLED, reason);
+};
+
+export const getCancellationReason = () => state.cancellationReason;

--- a/packages/cypress-cloud/package.json
+++ b/packages/cypress-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-cloud",
-  "version": "1.5.6",
+  "version": "1.5.7-beta.0",
   "main": "./dist/index.js",
   "author": "Currents Software Inc",
   "homepage": "https://github.com/currents-dev/cypress-cloud",
@@ -33,6 +33,7 @@
     "@release-it/conventional-changelog": "^5.1.1",
     "@swc/core": "^1.3.23",
     "@swc/jest": "^0.2.24",
+    "@types/bluebird": "^3.5.38",
     "@types/debug": "^4.1.7",
     "@types/getos": "^3.0.1",
     "@types/is-ci": "^3.0.0",
@@ -55,6 +56,7 @@
     "async-wait-until": "^2.0.12",
     "axios": "^1.2.0",
     "axios-retry": "^3.4.0",
+    "bluebird": "^3.7.2",
     "chalk": "^4.1.2",
     "commander": "^10.0.0",
     "common-path-prefix": "^3.0.0",

--- a/packages/cypress-cloud/types.ts
+++ b/packages/cypress-cloud/types.ts
@@ -107,6 +107,7 @@ export type SummaryResult = Record<string, CypressCommandLine.CypressRunResult>;
 // Explicitly filter cypress record-related flags - prevent triggering recording mode to avoid confusion
 export type StrippedCypressModuleAPIOptions = Omit<
   Partial<CypressCommandLine.CypressRunOptions>,
+  | "autoCancelAfterFailures"
   | "tag"
   | "spec"
   | "exit"
@@ -161,6 +162,9 @@ export type CurrentsRunParameters = StrippedCypressModuleAPIOptions & {
 
   /** "e2e" or "component", the default value is "e2e" */
   testingType?: TestingType;
+
+  /** Automatically abort the run after the specified number of failed tests. Overrides the default project settings. If set, must be a positive integer or "false" to disable (Currents-only) */
+  autoCancelAfterFailures?: number | false;
 };
 
 // User-facing `run` interface
@@ -175,4 +179,5 @@ export interface ValidatedCurrentsParameters extends CurrentsRunParameters {
   readonly testingType: TestingType;
   readonly recordKey: string;
   readonly tag: string[];
+  readonly autoCancelAfterFailures: number | false | undefined;
 }


### PR DESCRIPTION
Implement `--auto-cancel-after-failures`. If set, overrides the project fail-fast strategy setting. If not set, uses the default project settings

- `false` prevents fail-fast
- `number` aborts the run across all the participating machines of more than x failed + skipped tests detected