### PR TITLE
Add cypress as a peerDependency for yarn/pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "prettier": "latest",
     "turbo": "^1.8.3"
   },
+  "peerDependencies": {
+    "cypress": "*"
+  },
   "engines": {
     "node": ">=14.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "prettier": "latest",
     "turbo": "^1.8.3"
   },
-  "peerDependencies": {
-    "cypress": "*"
-  },
   "engines": {
     "node": ">=14.0.0"
   },

--- a/packages/cypress-cloud/package.json
+++ b/packages/cypress-cloud/package.json
@@ -72,6 +72,9 @@
     "tmp-promise": "^3.0.3",
     "ws": "^8.12.1"
   },
+  "peerDependencies": {
+    "cypress": ">=10.0.0"
+  },
   "bin": {
     "cypress-cloud": "./dist/bin/cli.js"
   },


### PR DESCRIPTION
Add `cypress` as a `peerDependency` so that more strict package managers like Yarn 2+ & pnpm know to symlink the right cypress version in.

In a monorepo with multiple cypress versions, without this cypress versions, cypress-cloud might `require.resolve` to the wrong cypress version.

Closes #117 