### PR TITLE
fix: remove unnecessary await before startWSS()

### DIFF
--- a/packages/cypress-cloud/lib/run.ts
+++ b/packages/cypress-cloud/lib/run.ts
@@ -115,7 +115,7 @@ export async function run(params: CurrentsRunParameters = {}) {
   info("🎥 Run URL:", bold(run.runUrl));
   cutInitialOutput();
 
-  await startWSS();
+  startWSS();
   listenToSpecEvents(
     configState,
     executionState,


### PR DESCRIPTION
`startWSS()` returns undefined so there is no reason to await.

If you prefer, I can change `startWSS()` to return a promise resolving when the server is started (and leave the `await`).