### PR TITLE
feat: support batch orchestration in non-currents

### DIFF
--- a/packages/cypress-cloud/lib/runner/runner.ts
+++ b/packages/cypress-cloud/lib/runner/runner.ts
@@ -84,25 +84,14 @@ async function runBatch(
     totalInstances: 0,
   };
 
-  if (isCurrents()) {
-    debug("Getting batched tasks: %d", params.batchSize);
-    batch = await createBatchedInstances({
-      ...runMeta,
-      batchSize: params.batchSize,
-    });
-    debug("Got batched tasks: %o", batch);
-  } else {
-    const response = await createInstance(runMeta);
+  debug("Getting batched tasks: %d", params.batchSize);
 
-    if (response.spec !== null && response.instanceId !== null) {
-      batch.specs.push({
-        spec: response.spec,
-        instanceId: response.instanceId,
-      });
-    }
-    batch.claimedInstances = response.claimedInstances;
-    batch.totalInstances = response.totalInstances;
-  }
+  batch = await createBatchedInstances({
+    ...runMeta,
+    batchSize: params.batchSize,
+  });
+
+  debug("Got batched tasks: %o", batch);
 
   if (batch.specs.length === 0) {
     return [];


### PR DESCRIPTION
The goal of this PR is to fix https://github.com/sorry-cypress/sorry-cypress/issues/766.

The corresponding change in sorry-cypress is at https://github.com/sorry-cypress/sorry-cypress/pull/859.

TODOs:
- [ ] add backward compatibility: when receiving 404 on `/runs/:id/cy/instances` (batch), never try again and instead use `/runs/:id/instances` (single instance).
- [ ] fix/add tests