### PR TITLE
feat: add retries for hard failures

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -118,13 +118,16 @@ module.exports = {
   // Additional headers for network requests, undefined by default
   networkHeaders: {
     "User-Agent": "Custom",
-    "x-ms-blob-type": "BlockBlob"
+    "x-ms-blob-type": "BlockBlob",
   },
   e2e: {
     batchSize: 3, // orchestration batch size for e2e tests (Currents only, read below)
   },
   component: {
     batchSize: 5, // orchestration batch size for component tests (Currents only, read below)
+  },
+  retry: {
+    hardFailureMaxRetries: 2, // max retries for hard Cypress failures, a hard failure is when Cyrpess crashes and doesn't report back any results (see https://docs.cypress.io/guides/guides/module-api#Handling-errors)
   },
 };
 ```
@@ -162,7 +165,7 @@ The configuration variables will resolve as follows:
 
 ## Batched Orchestration
 
-This package uses its own orchestration and reporting protocol that is independent of cypress native implementation. The new [orchestration protocol]([https://currents.dev/readme/integration-with-cypress/cypress-cloud#batched-orchestration](https://currents.dev/readme/integration-with-cypress/cypress-cloud/batched-orchestration)) uses cypress in "offline" mode and allows batching multiple spec files for better efficiency. You can adjust the batching configuration in `currents.config.js` and use different values for e2e and component tests.
+This package uses its own orchestration and reporting protocol that is independent of cypress native implementation. The new [orchestration protocol](<[https://currents.dev/readme/integration-with-cypress/cypress-cloud#batched-orchestration](https://currents.dev/readme/integration-with-cypress/cypress-cloud/batched-orchestration)>) uses cypress in "offline" mode and allows batching multiple spec files for better efficiency. You can adjust the batching configuration in `currents.config.js` and use different values for e2e and component tests.
 
 ## API
 

--- a/examples/webapp/currents.config.js
+++ b/examples/webapp/currents.config.js
@@ -9,5 +9,8 @@ module.exports = {
     ? "Ij0RfK"
     : "Ij0RfK",
   // cloudServiceUrl: "http://localhost:1234",
-  userAgent: "custom",
+  // userAgent: "custom",
+  retry: {
+    hardFailureMaxRetries: 2,
+  },
 };

--- a/packages/cypress-cloud/lib/config/config.ts
+++ b/packages/cypress-cloud/lib/config/config.ts
@@ -14,6 +14,10 @@ export type E2EConfig = {
 export type ComponentConfig = {
   batchSize: number;
 };
+
+type RetryConfig = {
+  hardFailureMaxRetries: number;
+};
 export type CurrentsConfig = {
   projectId?: string;
   recordKey?: string;
@@ -21,6 +25,7 @@ export type CurrentsConfig = {
   e2e: E2EConfig;
   component: ComponentConfig;
   networkHeaders?: Record<string, string>;
+  retry?: RetryConfig;
 };
 
 let _config: CurrentsConfig | null = null;

--- a/packages/cypress-cloud/lib/cypress/cypress.ts
+++ b/packages/cypress-cloud/lib/cypress/cypress.ts
@@ -59,9 +59,10 @@ export async function runSpecFile(
 
   let retries = 0;
   const currentsConfig = await getCurrentsConfig();
+
   while (
     currentsConfig.retry &&
-    retries < currentsConfig.retry.hardFailureMaxRetries &&
+    retries < (currentsConfig.retry.hardFailureMaxRetries ?? 0) &&
     result.status === "failed"
   ) {
     warn("Cypress runner failed with message: %s", result.message);


### PR DESCRIPTION
Retry Cypress hard failures for up to `retry.hardFailureMaxRetries` times. Hard failure is when cypress didn't succeed to run tests and crashed.